### PR TITLE
add reference of project repository on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     description='Django integration with WordPress authentication and roles / capabilities system.',
     long_description=open('README.rst').read(),
     include_package_data=True,
+    url='https://github.com/dellis23/django-wordpress-auth',
     packages=[
         'wordpress_auth',
     ],


### PR DESCRIPTION
By visiting the [pypi](https://pypi.python.org/pypi/django-wordpress-auth/), there is no reference about this repository or any hint of who the author.
This makes it complicated the lives of those who want to help this project or report a issue.

This solves that problem.
