### PR TITLE
Add a middleware to set REMOTE_USER

### DIFF
--- a/wordpress_auth/middleware.py
+++ b/wordpress_auth/middleware.py
@@ -6,3 +6,8 @@ from wordpress_auth.utils import get_wordpress_user
 class WordPressAuthMiddleware(object):
     def process_request(self, request):
         request.wordpress_user = SimpleLazyObject(lambda: get_wordpress_user(request))
+
+class WordPressRemoteUserMiddleware(object):
+    def process_request(self, request):
+        if request.wordpress_user:
+            request.META['REMOTE_USER'] = request.wordpress_user.login


### PR DESCRIPTION
If user is authenticated in wordpress sets the user login in request.META['REMOTE_USER'], this enables Django [remote user authentication mechanism](https://docs.djangoproject.com/en/1.8/howto/auth-remote-user/). As a result you'll have a regular `request.user` available in your views with all the usual methods to check permissions against Django permission system.

To enable this behavior in Django, set these values in settings.py:

```
MIDDLEWARE_CLASSES = (
    ...
    'wordpress_auth.middleware.WordPressAuthMiddleware',
    'wordpress_auth.middleware.WordPressRemoteUserMiddleware',
    'django.contrib.auth.middleware.AuthenticationMiddleware',
    'django.contrib.auth.middleware.RemoteUserMiddleware',
    ...
)

AUTHENTICATION_BACKENDS = (
    'django.contrib.auth.backends.RemoteUserBackend',
)
```
