### PR TITLE
updated README to clarify which of Wordpress' keys/salts to use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,18 @@ Installation
 
 Add your WordPress's auth keys and salts (found in wp-config.php) to your settings.py.
 
+The `WORDPRESS_LOGGED_IN_KEY` value comes from your Wordpress installations
+
+.. sourcecode:: php
+
+    define('LOGGED_IN_KEY',    'rs&^D%jPdu=vk|VVDsdfsdgsdgsdg9sd87f98s7h[Xm$3gT/@1xdas');
+
+while `WORDPRESS_LOGGED_IN_SALT` value comess from 
+
+.. sourcecode:: php
+
+    define('LOGGED_IN_SALT',   '3]x^n{d8=su23902iu09jdc09asjd09asjd09jasdV-Lv-OydAQ%?~');
+
 .. sourcecode:: python
 
     WORDPRESS_LOGGED_IN_KEY = "rs&^D%jPdu=vk|VVDsdfsdgsdgsdg9sd87f98s7h[Xm$3gT/@1xdasd"

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ The `WORDPRESS_LOGGED_IN_KEY` value comes from your Wordpress installations
 
     define('LOGGED_IN_KEY',    'rs&^D%jPdu=vk|VVDsdfsdgsdgsdg9sd87f98s7h[Xm$3gT/@1xdas');
 
-while `WORDPRESS_LOGGED_IN_SALT` value comess from 
+while `WORDPRESS_LOGGED_IN_SALT` value comes from 
 
 .. sourcecode:: php
 


### PR DESCRIPTION
In reference to Issue #7 I've updated the `README.rst`
