### PR TITLE
Allow the specification of WORDPRESS_COOKIEHASH in the django settings

### DIFF
--- a/wordpress_auth/__init__.py
+++ b/wordpress_auth/__init__.py
@@ -5,3 +5,4 @@ from django.conf import settings
 WORDPRESS_TABLE_PREFIX = getattr(settings, 'WORDPRESS_TABLE_PREFIX', 'wp_')
 WORDPRESS_LOGGED_IN_KEY = getattr(settings, 'WORDPRESS_LOGGED_IN_KEY')
 WORDPRESS_LOGGED_IN_SALT = getattr(settings, 'WORDPRESS_LOGGED_IN_SALT')
+WORDPRESS_COOKIEHASH = getattr(settings, 'WORDPRESS_COOKIEHASH', None)

--- a/wordpress_auth/utils.py
+++ b/wordpress_auth/utils.py
@@ -5,7 +5,8 @@ from time import time
 from django.utils.six.moves.urllib.parse import urljoin, unquote_plus
 from django.utils.encoding import force_bytes
 
-from wordpress_auth import WORDPRESS_LOGGED_IN_KEY, WORDPRESS_LOGGED_IN_SALT
+from wordpress_auth import (WORDPRESS_LOGGED_IN_KEY, WORDPRESS_LOGGED_IN_SALT,
+                            WORDPRESS_COOKIEHASH)
 from wordpress_auth.models import WpOptions, WpUsers
 
 
@@ -21,7 +22,11 @@ def get_login_url():
 
 
 def get_wordpress_user(request):
-    cookie_hash = hashlib.md5(force_bytes(get_site_url())).hexdigest()
+    if WORDPRESS_COOKIEHASH is None:
+        cookie_hash = hashlib.md5(force_bytes(get_site_url())).hexdigest()
+    else:
+        cookie_hash = WORDPRESS_COOKIEHASH
+
     cookie = request.COOKIES.get('wordpress_logged_in_' + cookie_hash)
 
     if cookie:


### PR DESCRIPTION
Allow the specification of WORDPRESS_COOKIEHASH in the django settings file, corresponding to that which can be specified in the wordpress config. If not set, use a hash of the site url, as usual.